### PR TITLE
Japanese support

### DIFF
--- a/javasource/watsonservices/utils/TextToSpeechService.java
+++ b/javasource/watsonservices/utils/TextToSpeechService.java
@@ -73,6 +73,9 @@ public class TextToSpeechService {
 			case IT_FRANCESCA:
 				voice = Voice.IT_FRANCESCA;
 				break;
+			case JA_EMI:
+				voice = Voice.JA_EMI;
+				break;
 		default:
 			break;
 		}


### PR DESCRIPTION
IBM Watson TextToSpeech now supports Japanese language.